### PR TITLE
Escape volume name

### DIFF
--- a/lib/fastlane/plugin/dmg/actions/dmg_action.rb
+++ b/lib/fastlane/plugin/dmg/actions/dmg_action.rb
@@ -26,7 +26,7 @@ module Fastlane
         Dir.mktmpdir('fldmg') do |dir|
           FileUtils.cp_r(input_path, dir)
 
-          Actions.sh "hdiutil create -fs #{params[:filesystem]} -volname #{params[:volume_name]} -srcfolder #{File.expand_path(input_path).shellescape} -ov -format #{params[:format]} -size #{params[:size]}m #{absolute_output_path.shellescape}"
+          Actions.sh "hdiutil create -fs #{params[:filesystem]} -volname #{params[:volume_name].shellescape} -srcfolder #{File.expand_path(input_path).shellescape} -ov -format #{params[:format]} -size #{params[:size]}m #{absolute_output_path.shellescape}"
         end
 
         UI.success "Successfuly generated dmg image at path #{absolute_output_path}"


### PR DESCRIPTION
Fixes error creating dmg when volume name includes spaces.